### PR TITLE
MDL-48468 cache: add support for port in server address

### DIFF
--- a/cache/stores/redis/lib.php
+++ b/cache/stores/redis/lib.php
@@ -137,7 +137,13 @@ class cachestore_redis extends cache_store implements cache_is_key_aware, cache_
      */
     protected function new_redis($server, $prefix = '') {
         $redis = new Redis();
-        if ($redis->connect($server)) {
+        $port = null;
+        if (strpos($server, ':')) {
+          $server_conf = explode(':', $server);
+          $server = $server_conf[0];
+          $port = $server_conf[1];
+        }
+        if ($redis->connect($server, $port)) {
             $redis->setOption(Redis::OPT_SERIALIZER, Redis::SERIALIZER_PHP);
             if (!empty($prefix)) {
                 $redis->setOption(Redis::OPT_PREFIX, $prefix);


### PR DESCRIPTION
Server address in store configuration does not support server:port values. This patch should fix it.
